### PR TITLE
Add an option for completion auto-rehash

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -32,8 +32,11 @@ else
   zstyle ':completion:*:*:*:*:processes' command "ps -u $USER -o pid,user,comm -w -w"
 fi
 
-# auto-complete external commands
-zstyle ':completion:*' rehash true
+# rehash on every external command completion request
+if [ "x$REHASH_COMPLETION" = "xtrue" ]; then
+  zstyle ':completion:*' rehash true
+  unset REHASH_COMPLETION
+fi
 
 # disable named-directories autocompletion
 zstyle ':completion:*:cd:*' tag-order local-directories directory-stack path-directories

--- a/templates/zshrc.zsh-template
+++ b/templates/zshrc.zsh-template
@@ -28,6 +28,11 @@ ZSH_THEME="robbyrussell"
 # Uncomment the following line to display red dots whilst waiting for completion.
 # COMPLETION_WAITING_DOTS="true"
 
+# Uncomment the following line to force a rehash on every external completion
+# request, so newly installed commands are automatically completed without
+# reloading the shell. Be aware that this may impact completion performance.
+# REHASH_COMPLETION="true"
+
 # Uncomment the following line if you want to disable marking untracked files
 # under VCS as dirty. This makes repository status check for large repositories
 # much, much faster.


### PR DESCRIPTION
Since rehashing on every completion request may impact performance, as discussed in [robbyrussel/oh-my-zsh#3456](https://github.com/robbyrussell/oh-my-zsh/pull/3456), we want to have it depend on an option.

I am open to suggestions if you have a better name than `$REHASH_COMPLETION`.